### PR TITLE
外形監視用のAPIを追加した

### DIFF
--- a/api/src/main/kotlin/com/kyotob/api/controller/PingController.kt
+++ b/api/src/main/kotlin/com/kyotob/api/controller/PingController.kt
@@ -1,0 +1,11 @@
+package com.kyotob.api.controller
+
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class PingController {
+  @RequestMapping(value = ["/ping"], method = [RequestMethod.GET], produces = ["application/json"])
+  fun index() = "{\"message\" : \"It works!\"}"
+}


### PR DESCRIPTION
開発中のクライアント(Androidアプリ)側でHTTPリクエストを飛ばしてレスポンスを処理できるようになってきたので、``/ping`` を叩くと毎回 ``{"message" : "It works!"}`` が返るようにしました。